### PR TITLE
ros-humble-moveit-config-utilsのアップデートに伴う修正

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,5 @@
 build/*
 install/*
 log/*
+
+**/.vscode/

--- a/zx120_moveit_config/config/moveit.rviz
+++ b/zx120_moveit_config/config/moveit.rviz
@@ -109,7 +109,7 @@ Visualization Manager:
         Robot Alpha: 0.5
         Robot Color: 150; 50; 150
         Show Robot Collision: false
-        Show Robot Visual: true
+        Show Robot Visual: false
         Show Trail: false
         State Display Time: 0.05 s
         Trail Step Size: 1

--- a/zx120_moveit_config/config/ompl_planning.yaml
+++ b/zx120_moveit_config/config/ompl_planning.yaml
@@ -2,7 +2,7 @@ planning_plugin: ompl_interface/OMPLPlanner
 start_state_max_bounds_error: 0.1
 jiggle_fraction: 0.05
 request_adapters: >-
-    default_planner_request_adapters/AddTimeParameterization
+    default_planner_request_adapters/AddTimeOptimalParameterization
     default_planner_request_adapters/ResolveConstraintFrames
     default_planner_request_adapters/FixWorkspaceBounds
     default_planner_request_adapters/FixStartStateBounds


### PR DESCRIPTION
## 変更内容

ros-humble-moveit-config-utilsのアップデートに伴い，default_planner_request_adapters/AddTimeParameterizationが使用不可となったため，
default_planner_request_adapters/AddTimeOptimalParameterizationを使用するように修正．

default_planner_request_adapters/AddTimeParameterizationのままでは，軌道にタイムスタンプが付与されず，rvizプラグインから軌道の実行ができない．